### PR TITLE
fixed handling of unknown requests

### DIFF
--- a/x/ibc-dns/client/handler.go
+++ b/x/ibc-dns/client/handler.go
@@ -20,7 +20,7 @@ func NewHandler(keeper Keeper) sdk.Handler {
 		case types.MsgDomainAssociationCreate:
 			return handleDomainAssociationCreate(ctx, msg, keeper)
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized IBC message type: %T", msg)
+			return nil, commontypes.ErrUnknownRequest
 		}
 	}
 }
@@ -46,13 +46,13 @@ func NewPacketReceiver(keeper Keeper) commontypes.PacketReceiver {
 	return func(ctx sdk.Context, packet channeltypes.Packet) (*sdk.Result, error) {
 		var data commontypes.PacketData
 		if err := types.ModuleCdc.UnmarshalJSON(packet.GetData(), &data); err != nil {
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized IBC packet type: %T", packet)
+			return nil, commontypes.ErrUnknownRequest
 		}
 		switch data := data.(type) {
 		case servertypes.DomainAssociationResultPacketData:
 			return handleDomainAssociationResultPacketData(ctx, keeper, packet, data)
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized IBC packet data type: %T", data)
+			return nil, commontypes.ErrUnknownRequest
 		}
 	}
 }
@@ -95,7 +95,7 @@ func NewPacketAcknowledgementReceiver(keeper Keeper) commontypes.PacketAcknowled
 		case servertypes.DomainAssociationCreatePacketAcknowledgement:
 			return handleDomainAssociationCreatePacketAcknowledgement(ctx, keeper, ack)
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized IBC packet data type: %T", data)
+			return nil, commontypes.ErrUnknownRequest
 		}
 	}
 }

--- a/x/ibc-dns/server/handler.go
+++ b/x/ibc-dns/server/handler.go
@@ -20,7 +20,7 @@ func NewPacketReceiver(keeper Keeper) commontypes.PacketReceiver {
 		case types.DomainAssociationCreatePacketData:
 			return handleDomainAssociationCreatePacketData(ctx, keeper, packet, data)
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized IBC packet data type: %T", data)
+			return nil, commontypes.ErrUnknownRequest
 		}
 	}
 }
@@ -64,7 +64,7 @@ func NewPacketAcknowledgementReceiver(keeper Keeper) commontypes.PacketAcknowled
 		case types.DomainAssociationResultPacketAcknowledgement:
 			return handleDomainAssociationResultPacketAcknowledgement(ctx, keeper, ack)
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized IBC packet data type: %T", data)
+			return nil, commontypes.ErrUnknownRequest
 		}
 	}
 }


### PR DESCRIPTION
When both client and server hander functions are registered

https://github.com/datachainlab/cosmos-sdk-interchain-dns/blob/master/x/ibc-dns/common/types/packet.go#L24

Fixed a condition on this line that didn't match